### PR TITLE
arm macos + linux by using the upcoming github m1 host

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,41 @@ on:
   pull_request:
 
 jobs:
+  build-macos-arm64:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Install build dependencies
+        run: brew install automake libtool
+      - name: Build native code
+        run: |
+          export CPPFLAGS="-I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin"
+          cd libjpeg-turbo
+          autoreconf -fiv
+          rm -rf build && mkdir build
+          cd build
+          ../configure --with-java
+          make
+          mv .libs/libturbojpeg.dylib .libs/libturbojpeg-arm64.dylib
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: configure log
+          path: libjpeg-turbo/build/config.log
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-macos-arm64
+          path: libjpeg-turbo/build/.libs/libturbojpeg-arm64.dylib
+          if-no-files-found: error
   build-macos-x86_64:
     runs-on: macos-latest
     steps:
@@ -39,6 +74,28 @@ jobs:
         with:
           name: artifacts-macos-x86_64
           path: libjpeg-turbo/build/.libs/libturbojpeg.dylib
+          if-no-files-found: error
+  build-linux-arm64:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build native code
+        run: |
+          docker build -f Dockerfile2014_arm . -t native_builder
+          docker run -v $(pwd):/build --user ${UID} -t native_builder /build/linux.sh
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: configure log
+          path: libjpeg-turbo/build/config.log
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-linux-arm64
+          path: libjpeg-turbo/build/.libs/libturbojpeg-arm64.so
           if-no-files-found: error
   build-linux-x86_64:
     runs-on: ubuntu-latest
@@ -94,7 +151,7 @@ jobs:
           path: libjpeg-turbo/build/**/turbojpeg.dll
           if-no-files-found: error
   build-package:
-    needs: [build-macos-x86_64, build-windows-x86_64, build-linux-x86_64]
+    needs: [build-macos-x86_64, build-windows-x86_64, build-linux-x86_64, build-macos-arm64, build-linux-arm64]
     runs-on: ubuntu-latest
     env:
       gradle_commands: --stacktrace clean jar
@@ -158,4 +215,6 @@ jobs:
             artifacts-macos-x86_64/*.dylib
             artifacts-linux-x86_64/*.so
             artifacts-windows-x86_64/Debug/*.dll
+            artifacts-macos-arm64/*.dylib
+            artifacts-linux-arm64/*.so
             libjpeg-turbo-java/*.jar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-macos-arm64:
-    runs-on: self-hosted
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
@@ -76,7 +76,7 @@ jobs:
           path: libjpeg-turbo/build/.libs/libturbojpeg.dylib
           if-no-files-found: error
   build-linux-arm64:
-    runs-on: self-hosted
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3

--- a/Dockerfile2014_arm
+++ b/Dockerfile2014_arm
@@ -1,0 +1,6 @@
+# Dockerfile for lowest common denominator Linux native artifact build
+# --------------------------------------------------------------------
+# Modified from TileDB-Java/ci/Dockerfile2010
+FROM quay.io/pypa/manylinux2014_aarch64
+
+RUN yum install -y java-1.8.0-openjdk-devel

--- a/jar-pack.sh
+++ b/jar-pack.sh
@@ -15,6 +15,10 @@ mkdir -p META-INF/lib/osx_64
 mv ../../artifacts-macos-x86_64/libturbojpeg.dylib META-INF/lib/osx_64/
 mkdir -p META-INF/lib/linux_64
 mv ../../artifacts-linux-x86_64/libturbojpeg.so META-INF/lib/linux_64/
+mkdir -p META-INF/lib/osx_arm64
+mv ../../artifacts-macos-arm64/libturbojpeg-arm64.dylib META-INF/lib/osx_arm64/libturbojpeg.dylib
+mkdir -p META-INF/lib/linux_arm64
+mv ../../artifacts-linux-arm64/libturbojpeg-arm64.so META-INF/lib/linux_arm64/libturbojpeg.so
 
 # repack the jar file to include the native libraries
 jar uvvf libjpeg-turbo*.jar META-INF/lib/*

--- a/linux.sh
+++ b/linux.sh
@@ -3,7 +3,11 @@
 set -x
 
 cd "$(dirname "${0}")"
-export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk.x86_64"
+if [ "$(uname -i)" = aarch64 ]; then
+    export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+else
+    export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk.x86_64"
+fi
 export CPPFLAGS="-I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux"
 cd libjpeg-turbo
 autoreconf -fiv
@@ -11,3 +15,6 @@ mkdir build
 cd build
 ../configure --with-java
 make
+if [ "$(uname -i)" = aarch64 ]; then
+    mv .libs/libturbojpeg.so .libs/libturbojpeg-arm64.so
+fi


### PR DESCRIPTION
- Building for mac is easy
- To build for linux, use docker likewise. manylinux_2010 doesn't have an arm image published but manylinux_2014 does have an arm image
- I propose sticking to v1.2.X for now. If you do update to v3.X, you would need to remove all the previous shared library builds, (because despite the java api for turbojpeg hasn't changed, the internal connection inside turbojpeg between its exposed API and the shared library has changed), hence needing to drop ppc, s390x builds, needing a major version bump for bioformats. But if you compile for 1.2.X, you can *add* these shared libraries to the current bioformats without needing to remove the old ones, and computers with these old architectures would continue to work.
- You can test this pull request now before GitHub has free public runners (as I do here: https://github.com/CGDogan/libjpeg-turbo-java/actions/runs/7199609084/job/19611649514). On an arm mac with Docker installed, you go to glencoesoftware/libjpeg-turbo-java settings, go to runners, download the macos runner, run config.sh, run ./run.sh, then this pull request will be tested on your computer automatically.

To switch to GitHub public runners (to check (?) is it ready https://github.com/github/roadmap/issues/819), a few little considerations:

- I replaced the expected `mkdir build` with `rm -rf build && mkdir build`, because it seems that the github runner on my computer doesn't delete the previous build files!
- We wont't know it now if the build-dependencies step requires some additional dependencies, since they might be already installed on my computer, but that's unlikely.
- Once github has the public runners, I might need to add a workflow step to install docker