### PR TITLE
arm windows by cross-compiling from linux x64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           name: artifacts-linux-x86_64
           path: libjpeg-turbo/build/.libs/libturbojpeg.so
           if-no-files-found: error
-  build-linux-x86_64-2:
+  build-windows-arm64-xcompile-linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -82,8 +82,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts-linux-x86_64
-          path: libjpeg-turbo/build_winarm/.libs/libturbojpeg.dll
+          name: artifacts-windows-arm64
+          path: libjpeg-turbo/build_winarm/.libs/libturbojpeg-arm64.dll
           if-no-files-found: error
   build-windows-x86_64:
     runs-on: windows-latest
@@ -117,7 +117,7 @@ jobs:
           path: libjpeg-turbo/build/**/turbojpeg.dll
           if-no-files-found: error
   build-package:
-    needs: [build-macos-x86_64, build-windows-x86_64, build-linux-x86_64]
+    needs: [build-macos-x86_64, build-windows-x86_64, build-linux-x86_64, build-windows-x86_64]
     runs-on: ubuntu-latest
     env:
       gradle_commands: --stacktrace clean jar
@@ -180,5 +180,6 @@ jobs:
           files: |
             artifacts-macos-x86_64/*.dylib
             artifacts-linux-x86_64/*.so
+            artifacts-windows-arm64/*.dll
             artifacts-windows-x86_64/Debug/*.dll
             libjpeg-turbo-java/*.jar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,27 @@ jobs:
           name: artifacts-linux-x86_64
           path: libjpeg-turbo/build/.libs/libturbojpeg.so
           if-no-files-found: error
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build native code
+        run: |
+          ./winarm64-xcompile-on-unix.sh
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: configure log
+          path: libjpeg-turbo/build/config.log
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-linux-x86_64
+          path: libjpeg-turbo/build_winarm/.libs/libturbojpeg.dll
+          if-no-files-found: error
   build-windows-x86_64:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           name: artifacts-linux-x86_64
           path: libjpeg-turbo/build/.libs/libturbojpeg.so
           if-no-files-found: error
-  build-linux-x86_64:
+  build-linux-x86_64-2:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Build native code
+      - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
+      - name: Build native code
         run: |
           ./winarm64-xcompile-on-unix.sh
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build native code
+        uses: goto-bus-stop/setup-zig@v2
         run: |
           ./winarm64-xcompile-on-unix.sh
       - uses: actions/upload-artifact@v3

--- a/jar-pack.sh
+++ b/jar-pack.sh
@@ -15,6 +15,8 @@ mkdir -p META-INF/lib/osx_64
 mv ../../artifacts-macos-x86_64/libturbojpeg.dylib META-INF/lib/osx_64/
 mkdir -p META-INF/lib/linux_64
 mv ../../artifacts-linux-x86_64/libturbojpeg.so META-INF/lib/linux_64/
+mkdir -p META-INF/lib/windows_arm64
+mv ../../artifacts-windows-arm64/libturbojpeg.dll META-INF/lib/windows_arm64/
 
 # repack the jar file to include the native libraries
 jar uvvf libjpeg-turbo*.jar META-INF/lib/*

--- a/winarm64-xcompile-on-unix.sh
+++ b/winarm64-xcompile-on-unix.sh
@@ -1,0 +1,21 @@
+if [ ! -d "jdk" ]; then
+    # https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-11
+    wget https://aka.ms/download-jdk/microsoft-jdk-11.0.21-windows-aarch64.zip -O jdk.zip
+    unzip jdk.zip
+    rm jdk.zip
+    mv jdk-11.0.21+9 jdk
+fi
+export JAVA_HOME="${PWD}/jdk"
+export CPPFLAGS="-I${JAVA_HOME}/include -I${JAVA_HOME}/include/win32"
+export CC="zig cc -target aarch64-windows"
+export CXX="zig c++ -target aarch64-windows"
+export AR="zig ar"
+export RANLIB="zig ranlib"
+cd libjpeg-turbo
+autoreconf -fiv
+mkdir build_winarm
+cd build_winarm
+../configure --with-java --host aarch64-windows
+make
+zig cc -target aarch64-windows .libs/libturbojpeg.a -shared -o .libs/libturbojpeg.dll
+

--- a/winarm64-xcompile-on-unix.sh
+++ b/winarm64-xcompile-on-unix.sh
@@ -17,5 +17,5 @@ mkdir build_winarm
 cd build_winarm
 ../configure --with-java --host aarch64-windows
 make
-zig cc -target aarch64-windows .libs/libturbojpeg.a -shared -o .libs/libturbojpeg.dll
+zig cc -target aarch64-windows .libs/libturbojpeg.a -shared -o .libs/libturbojpeg-arm64.dll
 


### PR DESCRIPTION
This is a different approach from #3. It doesn't require special GitHub runners so it's ready now. It can be used as a base for crosscompiling to many different platforms. It uses zig, which is known for its convenience in crosscompiling C,C++ by recompiling relevant libraries on-demand during compilation.

Zig crosscompilation has partial support for [these targets](https://ziglang.org/download/0.11.0/release-notes.html#Tier-3-Support) and aims to have full support for [these](https://ziglang.org/download/0.11.0/release-notes.html#Tier-1-Support)

Without crosscompilation, arm windows may take many years to support since GitHub hasn't even announced for linux arm builders now.