### PR TITLE
Add infrastructure to publish library to Maven Central

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           path: libjpeg-turbo/build/.libs/libturbojpeg.so
           if-no-files-found: error
   build-windows-x86_64:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       gradle_commands: --stacktrace clean jar
+      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+      JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_TOKEN }}
+      JRELEASER_NEXUS2_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
+      JRELEASER_NEXUS2_TOKEN: ${{ secrets.JRELEASER_NEXUS2_TOKEN }}
+      JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+      JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+      JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+      JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -199,6 +207,10 @@ jobs:
       - name: Run commands
         run: |
           ./gradlew ${{ env.gradle_commands }}
+      - name: Publish
+        if: github.event_name != 'pull_request'
+        run: |
+          ./gradlew publish jreleaserDeploy
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,33 +150,8 @@ jobs:
           name: artifacts-windows-x86_64
           path: libjpeg-turbo/build/**/turbojpeg.dll
           if-no-files-found: error
-  build-package:
-    needs: [build-macos-arm64, build-macos-x86_64, build-windows-x86_64, build-linux-arm64, build-linux-x86_64]
-    runs-on: ubuntu-latest
-    env:
-      gradle_commands: --stacktrace clean jar
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Run commands
-        run: |
-          ./gradlew ${{ env.gradle_commands }}
-      - name: Download artifacts from build
-        uses: actions/download-artifact@v8
-      - name: List artifacts
-        run: ls -R
-      - name: Repack jar
-        run: ./jar-pack.sh
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: libjpeg-turbo-java
-          path: build/libs/*.jar
   test:
-    needs: build-package
+    needs: [build-macos-arm64, build-macos-x86_64, build-windows-x86_64, build-linux-arm64, build-linux-x86_64]
     strategy:
       matrix:
         os: [ubuntu-24.04-arm, ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
@@ -191,34 +166,47 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '${{ matrix.java }}'
-      - name: Run commands
-        run: |
-          ./gradlew ${{ env.gradle_commands }}
-      - name: Download artifacts from build
-        uses: actions/download-artifact@v8
-      - name: Move packed jar to build dir
-        run: rm build/libs/libjpeg-turbo*.jar; mv libjpeg-turbo-java/libjpeg-turbo*.jar build/libs/
-      - name: Run tests
-        run: |
-          ./gradlew ${{ env.test_commands }}
-
-  release:
-    if: startsWith(github.ref, 'refs/tags')
-    needs: [build-package]
-    runs-on: ubuntu-latest
-    steps:
       - name: Download artifacts from build
         uses: actions/download-artifact@v8
       - name: List artifacts
         run: ls -R
-      - name: Release
+      - name: Move pre-built binaries under resources
+        run: ./jar-pack.sh
+        shell: bash
+      - name: Run commands
         run: |
-          gh release create --generate-notes "${GITHUB_REF#refs/tags/}" \
-          artifacts-macos-arm64/*.dylib \
-          artifacts-macos-x86_64/*.dylib \
-          artifacts-linux-arm64/*.so \
-          artifacts-linux-x86_64/*.so \
-          artifacts-windows-x86_64/Debug/*.dll \
-          libjpeg-turbo-java/*.jar
+          ./gradlew ${{ env.gradle_commands }}
+      - name: Run tests
+        run: |
+          ./gradlew ${{ env.test_commands }}
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      gradle_commands: --stacktrace clean jar
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v8
+      - name: List artifacts
+        run: ls -R
+      - name: Move pre-built binaries under resources
+        run: ./jar-pack.sh
+      - name: Run commands
+        run: |
+          ./gradlew ${{ env.gradle_commands }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: libjpeg-turbo-java
+          path: build/libs/*.jar
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          gh release create --generate-notes "${GITHUB_REF#refs/tags/}" build/libs/*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (C)2011 D. R. Commander.  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id 'maven-publish'
+    id 'org.jreleaser' version '1.24.0'
 }
 
 group = 'com.glencoesoftware'
@@ -7,6 +9,11 @@ version = '0.1.0-SNAPSHOT'
 
 compileJava {
     options.release = 11
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 repositories {
@@ -36,7 +43,7 @@ jar {
             "Build-Jdk": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
             "Built-By": System.properties['user.name'],
             "Built-On": new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
-            "Main-Class": "com.glencoesoftware.turbojpeg.TJ",
+            "Main-Class": "org.libjpegturbo.turbojpeg.TJ",
             "Implementation-Version": version,
             "Implementation-Build": "git rev-parse --verify HEAD".execute().getText().trim()
         )
@@ -49,4 +56,82 @@ test {
     classpath = files("${buildDir}/libs/libjpeg-turbo-java-${version}.jar") + classpath
 }
 
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.glencoesoftware'
+            artifactId = 'libjpeg-turbo'
 
+            from components.java
+
+            pom {
+                name = 'libjpeg-turbo'
+                description = 'JNI-based wrapper around the libjpeg-turbo library.'
+                url = 'https://github.com/glencoesoftware/libjpeg-turbo-java'
+                inceptionYear = '2022'
+                licenses {
+                    license {
+                        name = 'BSD 3-Clause "New" or "Revised" License'
+                        url = 'https://opensource.org/licenses/BSD-3-Clause'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'chris-allan'
+                        name = 'Chris Allan'
+                    }
+                    developer {
+                        id = 'melissalinkert'
+                        name = 'Melissa Linkert'
+                    }
+                    developer {
+                        id = 'sbesson'
+                        name = 'Sébastien Besson'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/glencoesoftware/libjpeg-turbo-java'
+                    developerConnection = 'scm:git:git@github.com:glencoesoftware/libjpeg-turbo-java'
+                    url = 'http://github.com/glencoesoftware/libjpeg-turbo-java'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            url = layout.buildDirectory.dir('staging-deploy')
+        }
+    }
+}
+
+jreleaser {
+    signing {
+        pgp {
+            active = 'ALWAYS'
+            armored = true
+        }
+    }
+    deploy {
+        maven {
+            mavenCentral {
+                'release-deploy' {
+                    active = 'ALWAYS'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepository('build/staging-deploy')
+                }
+            }
+            nexus2 {
+              'snapshot-deploy' {
+                active = 'SNAPSHOT'
+                snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
+                applyMavenCentralRules = true
+                snapshotSupported = true
+                closeRepository = true
+                releaseRepository = true
+                stagingRepository('build/staging-deploy')
+            }
+        }
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-group = 'com.glencoesoftware.turbojpeg'
+group = 'com.glencoesoftware'
 version = '0.1.0-SNAPSHOT'
 
 compileJava {

--- a/jar-pack.sh
+++ b/jar-pack.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
+# Move compiled binaries for each platform under src/main/resources
+# for packaging
+# For each supported platform, create the lib directory suitable for
+# https://github.com/scijava/native-lib-loader
+# and move the corresponding library file
 
 set -x
 
-cd build/libs
-# unpack the Java-only jar
-jar xvvf libjpeg-turbo*.jar
-
-# for each platform, create the lib directory suitable for
-# https://github.com/scijava/native-lib-loader
-# and move the corresponding library file
-mkdir -p META-INF/lib/windows_64
-mv ../../artifacts-windows-x86_64/Debug/turbojpeg.dll META-INF/lib/windows_64/
-mkdir -p META-INF/lib/osx_arm64
-mv ../../artifacts-macos-arm64/libturbojpeg.dylib META-INF/lib/osx_arm64/
-mkdir -p META-INF/lib/osx_64
-mv ../../artifacts-macos-x86_64/libturbojpeg.dylib META-INF/lib/osx_64/
-mkdir -p META-INF/lib/linux_arm64
-mv ../../artifacts-linux-arm64/libturbojpeg.so META-INF/lib/linux_arm64/
-mkdir -p META-INF/lib/linux_64
-mv ../../artifacts-linux-x86_64/libturbojpeg.so META-INF/lib/linux_64/
-
-# repack the jar file to include the native libraries
-jar uvvf libjpeg-turbo*.jar META-INF/lib/*
+mkdir -p src/main/resources/META-INF/lib/windows_64
+mv artifacts-windows-x86_64/Debug/turbojpeg.dll src/main/resources/META-INF/lib/windows_64/
+mkdir -p src/main/resources/META-INF/lib/osx_arm64
+mv artifacts-macos-arm64/libturbojpeg.dylib src/main/resources/META-INF/lib/osx_arm64/
+mkdir -p src/main/resources/META-INF/lib/osx_64
+mv artifacts-macos-x86_64/libturbojpeg.dylib src/main/resources/META-INF/lib/osx_64/
+mkdir -p src/main/resources/META-INF/lib/linux_arm64
+mv artifacts-linux-arm64/libturbojpeg.so src/main/resources/META-INF/lib/linux_arm64/
+mkdir -p src/main/resources/META-INF/lib/linux_64
+mv artifacts-linux-x86_64/libturbojpeg.so src/main/resources/META-INF/lib/linux_64/


### PR DESCRIPTION
This adds the infrastructure to publish this library to Maven Central and fixes #2

Build changes:

- the component group is changed to `com.glencoesoftware` to match the namespace in Maven Central
- a top-level  BSD-3 clause  license is added to the repository consistently with the underlying library
- a `jreleaser` configuration is added to `build.gradle` as described in https://jreleaser.org/guide/latest/examples/maven/maven-central.html with the minimal metadata requirements for publishing to Central, both as releases and as SNAPSHOTS
- the `jar-pack.sh` utility is refactored to copy the pre-compiled libraries under `src/main/resources` allowing `./gradlew jar` to automatically bundle them in the packaged library

GitHub actions changes:
- the Windows GitHub runner label is updated to `windows-2022` as the latest image is using Visual Studio 2026 and is incompatible with the CMake requirements of the 1.x library - see https://github.com/actions/runner-images/issues/14017. This can probably be reviewed once this component is upgraded to build `libjpeg-turbo 3.x`
- the different phases are updated to use the new `jar-pack.sh` logic before running the `./gradlew build` target
- the test phase is moved before the packaging phase which also includes a deployment to Maven Central on push
- the minimal set of environment variables allowing to sign and deploy SNAPSHOT and release artifacts to Maven Central are added to the environment of the deploy phase